### PR TITLE
Remove now defunct plib.h

### DIFF
--- a/OBCI32_SD/utility/Sd2Card.cpp
+++ b/OBCI32_SD/utility/Sd2Card.cpp
@@ -18,7 +18,6 @@
  * <http://www.gnu.org/licenses/>.
  */
 #include <p32xxxx.h>
-#include <plib.h>
 
 
 


### PR DESCRIPTION
The use of plib.h has been deprecated. Since it is not actually used in this library its inclusion is pointless and breaks compilation with a modern chipKIT installation.